### PR TITLE
Fix string for required Python version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,5 +16,5 @@ setup(
     long_description=long_description,
     long_description_content_type="text/markdown",
     test_suite="tests",
-    python_requires=">=3.8.*",
+    python_requires=">=3.8",
 )


### PR DESCRIPTION
Installation with Python 3.11 failed because of wrong string for `python_requires`:

```
$ pip install .
Looking in indexes: https://pypi.org/simple, https://pypi.ngc.nvidia.com
Processing /home/stweil/src/github/OpenITI/oimdp
  Preparing metadata (setup.py) ... error
  error: subprocess-exited-with-error

  × python setup.py egg_info did not run successfully.
  │ exit code: 1
  ╰─> [1 lines of output]
      error in oimdp setup command: 'python_requires' must be a string containing valid version specifiers; Invalid specifier: '>=3.8.*'
      [end of output]

  note: This error originates from a subprocess, and is likely not a problem with pip.
error: metadata-generation-failed

× Encountered error while generating package metadata.
╰─> See above for output.

note: This is an issue with the package mentioned above, not pip.
```